### PR TITLE
php snippets $ sign problem solved

### DIFF
--- a/dist/snippets/php.snippets
+++ b/dist/snippets/php.snippets
@@ -17,15 +17,15 @@ snippet i
 		${2}
 	}
 snippet t.
-	$this->${1}
+	\$this->${1}
 snippet f
-	function ${1:foo}(${2:array }${3:$bar})
+	function ${1:foo}(${2:array }${3:\$bar})
 	{
 		${4}
 	}
 # method
 snippet m
-	${1:abstract }${2:protected}${3: static} function ${4:foo}(${5:array }${6:$bar})
+	${1:abstract }${2:protected}${3: static} function ${4:foo}(${5:array }${6:\$bar})
 	{
 		${7}
 	}
@@ -34,32 +34,32 @@ snippet sm
 	/**
 	 * Sets the value of ${1:foo}
 	 *
-	 * @param ${2:$1} $$1 ${3:description}
+	 * @param ${2:\$1} $\$1 ${3:description}
 	 *
 	 * @return ${4}
 	 */
-	${5:public} function set${6:$2}(${7:$2 }$$1)
+	${5:public} function set${6:\$2}(${7:\$2 }$\$1)
 	{
-		$this->${8:$1} = $$1;
-		return $this;
+		\$this->${8:\$1} = $\$1;
+		return \$this;
 	}${9}
 # getter method
 snippet gm
 	/**
 	 * Gets the value of ${1:foo}
 	 *
-	 * @return ${2:$1}
+	 * @return ${2:\$1}
 	 */
-	${3:public} function get${4:$2}()
+	${3:public} function get${4:\$2}()
 	{
-		return $this->${5:$1};
+		return \$this->${5:\$1};
 	}${6}
 #setter
 snippet $s
-	${1:$foo}->set${2:Bar}(${3});
+	${1:\$foo}->set${2:Bar}(${3});
 #getter
 snippet $g
-	${1:$foo}->get${2:Bar}();
+	${1:\$foo}->get${2:Bar}();
 
 # Tertiary conditional
 snippet =?:
@@ -68,21 +68,21 @@ snippet ?:
 	${1:true} ? ${2:a} : ${3}
 
 snippet C
-	$_COOKIE['${1:variable}']${2}
+	\$_COOKIE['${1:variable}']${2}
 snippet E
-	$_ENV['${1:variable}']${2}
+	\$_ENV['${1:variable}']${2}
 snippet F
-	$_FILES['${1:variable}']${2}
+	\$_FILES['${1:variable}']${2}
 snippet G
-	$_GET['${1:variable}']${2}
+	\$_GET['${1:variable}']${2}
 snippet P
-	$_POST['${1:variable}']${2}
+	\$_POST['${1:variable}']${2}
 snippet R
-	$_REQUEST['${1:variable}']${2}
+	\$_REQUEST['${1:variable}']${2}
 snippet S
-	$_SERVER['${1:variable}']${2}
+	\$_SERVER['${1:variable}']${2}
 snippet SS
-	$_SESSION['${1:variable}']${2}
+	\$_SESSION['${1:variable}']${2}
 
 # the following are old ones
 snippet inc
@@ -134,7 +134,7 @@ snippet doc_c
 	${1:}class ${2:}
 	{
 		${7}
-	} // END $1class $2
+	} // END \$1class \$2
 # Constant Definition - post doc
 snippet doc_dp
 	/**
@@ -180,8 +180,8 @@ snippet doc_h
 	 * ${1}
 	 *
 	 * @author ${2:`g:snips_author`}
-	 * @version ${3:$Id$}
-	 * @copyright ${4:$2}, `strftime('%d %B, %Y')`
+	 * @version ${3:\$Id$}
+	 * @copyright ${4:\$2}, `strftime('%d %B, %Y')`
 	 * @package ${5:default}
 	 */
 
@@ -262,7 +262,7 @@ snippet case
 		${2:// code...}
 		break;${3}
 snippet for
-	for ($${2:i} = 0; $$2 < ${1:count}; $$2${3:++}) {
+	for ($${2:i} = 0; $\$2 < ${1:count}; $\$2${3:++}) {
 		${4: // code...}
 	}
 snippet foreach
@@ -279,11 +279,11 @@ snippet array
 snippet try
 	try {
 		${2}
-	} catch (${1:Exception} $e) {
+	} catch (${1:Exception} \$e) {
 	}
 # lambda with closure
 snippet lambda
-	${1:static }function (${2:args}) use (${3:&$x, $y /*put vars in scope (closure) */}) {
+	${1:static }function (${2:args}) use (${3:&\$x, \$y /*put vars in scope (closure) */}) {
 		${4}
 	};
 # pre_dump();
@@ -305,24 +305,24 @@ snippet gs
 	/**
 	 * Gets the value of ${1:foo}
 	 *
-	 * @return ${2:$1}
+	 * @return ${2:\$1}
 	 */
-	public function get${3:$2}()
+	public function get${3:\$2}()
 	{
-		return $this->${4:$1};
+		return \$this->${4:\$1};
 	}
 
 	/**
-	 * Sets the value of $1
+	 * Sets the value of \$1
 	 *
-	 * @param $2 $$1 ${5:description}
+	 * @param \$2 $\$1 ${5:description}
 	 *
 	 * @return ${6}
 	 */
-	public function set$3(${7:$2 }$$1)
+	public function set\$3(${7:\$2 }$\$1)
 	{
-		$this->$4 = $$1;
-		return $this;
+		\$this->\$4 = $\$1;
+		return \$this;
 	}${8}
 # anotation, get, and set, useful for doctrine
 snippet ags
@@ -333,15 +333,15 @@ snippet ags
 	 */
 	${2:protected} $${3:foo};
 
-	public function get${4:$3}()
+	public function get${4:\$3}()
 	{
-		return $this->$3;
+		return \$this->\$3;
 	}
 
-	public function set$4(${5:$4 }$${6:$3})
+	public function set\$4(${5:\$4 }$${6:\$3})
 	{
-		$this->$3 = $$6;
-		return $this;
+		\$this->\$3 = $\$6;
+		return \$this;
 	}
 snippet rett
 	return true;


### PR DESCRIPTION
php snippets dollar sign problem solved , for example when we type C then enter it show ['variable'] instead of $_COOKIE['variable'] , another example when we type t. enter it shows -> insted of $this-> , 
all $ sign bug fixes in php.snippets file