### PR TITLE
updated rust snippet, added missing assert_ne macro

### DIFF
--- a/dist/snippets/rust.snippets
+++ b/dist/snippets/rust.snippets
@@ -82,6 +82,8 @@ snippet assert
 	assert!(…);
 snippet assert_eq
 	assert_eq!(${1}, ${2});
+snippet assert_ne
+	assert_ne!(${1}, ${2});
 snippet bench
 	#[bench]
 	fn ${1:name}(b: &mut test::Bencher) {


### PR DESCRIPTION
updated rust snippet, added missing assert not equal macro
```assert_ne!(.,.);```